### PR TITLE
Reestabelecendo o funcionamento do Tracelog com base em cache

### DIFF
--- a/app/Helpers/CacheHelper.php
+++ b/app/Helpers/CacheHelper.php
@@ -17,7 +17,7 @@ class CacheHelper implements CacheHelperInterface
      */
     public static function set(string $key, string $value, ?string $drive = 'apc'): bool
     {
-        return Cache::store($drive)->put($key, $value);;
+        return Cache::store($drive)->put($key, $value);
     }
 
     /**

--- a/app/Helpers/CacheHelper.php
+++ b/app/Helpers/CacheHelper.php
@@ -1,0 +1,44 @@
+<?php 
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use Cache;
+
+class CacheHelper implements CacheHelperInterface
+{
+    /**
+     * Salva o valor de um item em cache pela chave.  
+     * @param string $key Nome da chave.
+     * @param string $value Valor a ser salvo.
+     * @param string $drive Define o drive de cache. Padrao: 'apc'. Mais opcoes em config/cache.php
+     * @return bool True se salvo com sucesso, do contrario, false.
+     */
+    public static function set(string $key, string $value, ?string $drive = 'apc'): bool
+    {
+        return Cache::store($drive)->put($key, $value);;
+    }
+
+    /**
+     * Busca o valor de um item em cache pela chave.  
+     * @param string $key Nome da chave.
+     * @param string $drive Define o drive de cache. Padrao: 'apc'. Mais opcoes em config/cache.php
+     * @return string|false O valor do item. False caso a chave nao exista.
+     */
+    public static function get(string $key, ?string $drive = 'apc')
+    {
+        return Cache::store($drive)->get($key, false);
+    }
+
+    /**
+     * Remove o valor de um item em cache pela chave.  
+     * @param string $key Nome da chave.
+     * @param string $drive Define o drive de cache. Padrao: apc. Mais opcoes em config/cache.php
+     * @return bool True se removido com sucesso, do contrario, false.
+     */
+    public static function remove(string $key, ?string $drive = 'apc'): bool
+    {
+        return Cache::store($drive)->forget($key);
+    }
+}

--- a/app/Helpers/CacheHelperInterface.php
+++ b/app/Helpers/CacheHelperInterface.php
@@ -1,0 +1,15 @@
+<?php 
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+interface CacheHelperInterface
+{
+    public static function set(string $key, string $value, ?string $drive): bool;
+    /**
+     * @return string|false
+     */
+    public static function get(string $key, ?string $drive);
+    public static function remove(string $key, ?string $drive): bool;
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,8 @@ RUN apt-get install -y --no-install-recommends \
   php7.4-opcache \
   php7.4-readline \
   php7.4-fpm \
-  php7.4-xdebug
+  php7.4-xdebug \
+  php7.4-apcu
 
 # Habilita o xdebug no PHP
 RUN echo "xdebug.mode=develop,coverage,debug" >> /etc/php/7.4/mods-available/xdebug.ini && \
@@ -190,7 +191,9 @@ WORKDIR /var/www/html
 
 USER contass
 
-#RUN chmod -R 777 /var/www/html/tmp/
+RUN sudo mkdir /var/www/html/tmp/
+
+RUN sudo chmod -R 777 /var/www/html/tmp/
 #
 #RUN /var/www/html/composer install
 

--- a/libs/db_stdlib.php
+++ b/libs/db_stdlib.php
@@ -112,13 +112,16 @@ function db_query($param1, $param2 = null, $param3 = "SQL")
         }
     }
 
+    $sTraceLogObjectName  = 'TracelogObject_'.db_getsession('DB_id_usuario', false);
+    $traceLogCacheExists = fn (string $name) => cache()->store('apc')->get($name, false);
     /*
-   * Trecho comentado devido a um problema na execuçðo do Duplos CGM executado via crontab.
-   */
-    if (db_getsession("DB_traceLog", false) != null) {
+     * Trecho comentado devido a um problema na execuçðo do Duplos CGM executado via crontab.
+     */
+    if ($traceLogCacheExists($sTraceLogObjectName)) {
 
         $oTraceLog = TraceLog::getInstance();
-        $oTraceLog->makeMessage($dbsql, (!$dbresult ? true : false));
+        if ($oTraceLog->isActive())
+            $oTraceLog->makeMessage($dbsql, (!$dbresult ? true : false));
     }
 
     if (db_getsession("DB_premenus", false) != null) {

--- a/resources/legacy/contabilidade/con1_ativatrace.RPC.php
+++ b/resources/legacy/contabilidade/con1_ativatrace.RPC.php
@@ -63,6 +63,7 @@ try {
   $oJson               = new services_json();
   $oParametros         = $oJson->decode(str_replace("\\", "", $_POST["json"]));
   $db_id_usuario       = db_getsession('DB_id_usuario');
+  $db_login            = db_getsession('DB_login');
 
   $oRetorno            = new stdClass();
   $oRetorno->iStatus   = 1;
@@ -78,7 +79,7 @@ try {
       if ($oParametros->lActive) {
         CacheHelper::remove('TracelogObject_'.$db_id_usuario);
 
-        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Enabled Trace Log - db_id_usuario: $db_id_usuario \n";
+        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Enabled Trace Log - db_id_usuario: $db_id_usuario. db_login: $db_login \n";
         $oTraceLog->write($sMessage);
       }
 
@@ -95,7 +96,7 @@ try {
       }
 
       if (!$oParametros->lActive) {
-        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Disabled Trace Log - db_id_usuario: $db_id_usuario \n";
+        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Disabled Trace Log - db_id_usuario: $db_id_usuario. db_login: $db_login \n";
         $oTraceLog->write($sMessage);
 
         CacheHelper::remove('TracelogObject_'.$db_id_usuario);

--- a/resources/legacy/contabilidade/con1_ativatrace.RPC.php
+++ b/resources/legacy/contabilidade/con1_ativatrace.RPC.php
@@ -1,4 +1,5 @@
 <?php
+use App\Helpers\CacheHelper;
 /*
  *     E-cidade Software Público para Gestão Municipal                
  *  Copyright (C) 2014  DBseller Serviços de Informática             
@@ -61,6 +62,7 @@ try {
 
   $oJson               = new services_json();
   $oParametros         = $oJson->decode(str_replace("\\", "", $_POST["json"]));
+  $db_id_usuario       = db_getsession('DB_id_usuario');
 
   $oRetorno            = new stdClass();
   $oRetorno->iStatus   = 1;
@@ -74,7 +76,10 @@ try {
 
 
       if ($oParametros->lActive) {
-        db_destroysession("TracelogObject");
+        CacheHelper::remove('TracelogObject_'.$db_id_usuario);
+
+        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Enabled Trace Log - db_id_usuario: $db_id_usuario \n";
+        $oTraceLog->write($sMessage);
       }
 
       $oTraceLog->setProperty('lActive', $oParametros->lActive);
@@ -84,18 +89,16 @@ try {
       $oTraceLog->setProperty('lShowTime', $oParametros->lShowTime);
       $oTraceLog->setProperty('lShowBackTrace', $oParametros->lShowBackTrace);
 
-      /**
-       * Compatibiliadade com a versÃ£o antiga
-       */
-      db_putsession("DB_traceLog", true);
 
       if (!$oParametros->lShowAccount) {
         db_destroysession("DB_traceLogAcount");
       }
 
       if (!$oParametros->lActive) {
+        $sMessage = "[INFO | ". date("d/m/Y - H:i:s") ."] Disabled Trace Log - db_id_usuario: $db_id_usuario \n";
+        $oTraceLog->write($sMessage);
 
-        db_destroysession("DB_traceLog");
+        CacheHelper::remove('TracelogObject_'.$db_id_usuario);
         //  db_destroysession("DB_traceLogAcount");
       }
 


### PR DESCRIPTION
1. O 'Tracelog' utilizava variáveis de sessão ($_SESSION['TracelogObject']) para salvar as opções de uso, escolhidos pelo usuário. No entanto, com a implementação da V3 e a possibilidade de serem abertas diversas aba, os dados da sessão não estavam sendo compartilhados com as requisições seguintes, realizadas em abas distintas a da rotina de ativação do Tracelog. 

Para isso, realizei alteração para que as opções  do Tracelog sejam salvas em cache, utilizando  a extensão APCu, que é um armazenamento em memória nativo do PHP utilizado pelo laravel.

2. Ainda, o Tracelog se utilizava das palavras reservadas 'begin', 'commit' e 'rollback' como filtro para identificar as querys que seriam mostradas no log. Porém, utilizando apenas estas keys, não estavam sendo retornados registros. 

Para isso, alterei as keys utilizadas para: 'select', 'insert', 'update' e 'delete'.

3. Apesar de ser nativa, a extensão precisa ser habilitada. 

Para isso foi adicionado ao dockerfile a extensão 'php7.4-apcu'.

Caso seja um container já em funcionamento, a extensão pode ser instalada usando o seguinte comando:
sudo apt install php-apcu

Para verificar se a extensão já existe no container, o comando a seguir deve retornar 'apcu':
php -m | grep apcu

4. Importante lembrar que o Tracelog salva/le o arquivo de log na pasta /tmp, com isso é importante que a mesma exista e possua as permissões necessárias. Durante a construção da imagem/container foram necessários os seguintes ajustes no dockerfile:
#Criando a pasta tmp
RUN sudo mkdir /var/www/html/tmp/
#Concedendo as permissões necessárias
RUN sudo chmod -R 777 /var/www/html/tmp/  