### PR TITLE
refactor(caixa): move parametro obrigatorio $iRecurso antes dos opcionais

### DIFF
--- a/repositories/caixa/relatorios/ReceitaPeriodoTesourariaRepositoryLegacy.php
+++ b/repositories/caixa/relatorios/ReceitaPeriodoTesourariaRepositoryLegacy.php
@@ -32,11 +32,11 @@ implements IReceitaPeriodoTesourariaRepository
         $iEmendaParlamentar,
         $iRegularizacaoRepasse,
         $iInstituicao,
+        $iRecurso,
         $sReceitas = NULL,
         $sEstrutura = NULL,
         $sContas = NULL,
-        $sContribuintes = NULL,
-        $iRecurso
+        $sContribuintes = NULL
     ) {
         $this->sTipo = $sTipo;
         $this->iAno = date("Y", strtotime($dDataInicial));
@@ -53,11 +53,11 @@ implements IReceitaPeriodoTesourariaRepository
             $iEmendaParlamentar,
             $iRegularizacaoRepasse,
             $iInstituicao,
+            $iRecurso,
             $sReceitas,
             $sEstrutura,
             $sContas,
             $sContribuintes,
-            $iRecurso
         );
     }
 

--- a/repositories/caixa/relatorios/SQLBuilder/ReceitaPeriodoTesourariaSQLBuilder.php
+++ b/repositories/caixa/relatorios/SQLBuilder/ReceitaPeriodoTesourariaSQLBuilder.php
@@ -125,11 +125,11 @@ class ReceitaPeriodoTesourariaSQLBuilder
         $iEmendaParlamentar,
         $iRegularizacaoRepasse,
         $iInstituicao,
+        $iRecurso,
         $sReceitas = NULL,
         $sEstrutura = NULL,
         $sContas = NULL,
-        $sContribuintes = NULL,
-        $iRecurso
+        $sContribuintes = NULL
     ) {
         $this->sTipo = $sTipo;
         $this->sTipoReceita = $sTipoReceita;

--- a/resources/legacy/caixa/cai2_correceitas002.php
+++ b/resources/legacy/caixa/cai2_correceitas002.php
@@ -71,11 +71,11 @@ $oReceitaPeriodoTesourariaRepository = new ReceitaPeriodoTesourariaRepositoryLeg
     $iEmendaParlamentar,
     $iRegularizacaoRepasse,
     $iInstituicao,
+    $iRecurso,
     $sReceitas,
     $sEstrutura,
     $sContas,
     $sContribuintes,
-    $iRecurso
 );
 
 if ($iFormato == 1) {


### PR DESCRIPTION
Move o parâmetro obrigatório $iRecurso para antes dos opcionais nos construtores e chamadas do relatório de receita por período. Isso corrige um deprecation do PHP 8.0. Rastreei todos os pontos que instanciam essas classes (só os 3 arquivos alterados); a reordenação é posicional e consistente, sem alteração de comportamento. Testado localmente. Ref #18