### PR TITLE
feat(compras): aprimora consulta de ordem de compra

### DIFF
--- a/database/migrations/2026_08_29_212355_desabilita_consulta_oc_antigo_e_habilita_consulta_oc_novo.php
+++ b/database/migrations/2026_08_29_212355_desabilita_consulta_oc_antigo_e_habilita_consulta_oc_novo.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DesabilitaConsultaOcAntigoEHabilitaConsultaOcNovo extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("
+            UPDATE configuracoes.db_itensmenu 
+            SET 
+                libcliente = true
+            WHERE funcao ilike 'com3_ordemdecompra001.php'
+                AND libcliente = false
+        ");
+
+        DB::statement("
+            UPDATE configuracoes.db_itensmenu 
+            SET 
+                libcliente = false
+            WHERE funcao ilike 'emp3_ordemcompra001.php'
+                AND libcliente = true
+        ");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("
+            UPDATE configuracoes.db_itensmenu 
+            SET 
+                libcliente = false
+            WHERE funcao ilike 'com3_ordemdecompra001.php'
+                AND libcliente = true
+        ");
+
+        DB::statement("
+            UPDATE configuracoes.db_itensmenu 
+            SET 
+                libcliente = true
+            WHERE funcao ilike 'emp3_ordemcompra001.php'
+                AND libcliente = false
+        ");
+    }
+}

--- a/model/MaterialCompras.model.php
+++ b/model/MaterialCompras.model.php
@@ -47,6 +47,13 @@ class MaterialCompras
   protected $sDescricao;
 
   /**
+   * Descrição do material
+   *
+   * @var ?string
+   */
+  protected $sComplemento;
+
+  /**
    * Verifica se o material é um serviço 
    *
    * @var bool
@@ -83,6 +90,7 @@ class MaterialCompras
 
         $oMaterial = db_utils::fieldsMemory($rsMaterial, 0, false, false, true);
         $this->sDescricao = $oMaterial->pc01_descrmater;
+        $this->sComplemento = $oMaterial->pc01_complmater;
         $this->lServico   = $oMaterial->pc01_servico == 't' ? true : false;
         $this->iCodanterior = $oMaterial->pc01_codmaterant;
       } else {
@@ -133,6 +141,21 @@ class MaterialCompras
     $this->sDescricao = $sDescricao;
   }
 
+  /**
+   * @return ?string
+   */
+  public function getComplemento()
+  {
+    return $this->sComplemento;
+  }
+
+  /**
+   * @param ?string $complemento
+   */
+  public function setComplemento(?string $complemento)
+  {
+    $this->sComplemento = $complemento;
+  }
 
   public function getElementos()
   {

--- a/model/compras/ItemOrdemDeCompra.model.php
+++ b/model/compras/ItemOrdemDeCompra.model.php
@@ -71,6 +71,12 @@ class ItemOrdemDeCompra {
   private $iQuantidadeAnulada;
 
   /**
+   * valor anulado do item
+   * @var number
+   */
+  private $nValorAnulado;
+
+  /**
    * retorna codigo do lancamento
    * @return integer
    */
@@ -136,6 +142,22 @@ class ItemOrdemDeCompra {
     $this->iQuantidadeAnulada = $iQuantidadeAnulada;
   }
 
+  /**
+   * Define o valor anulado do item
+   * @param float $valorAnulado
+   */
+  public function setValorAnulado(float $valorAnulado ) {
+    $this->nValorAnulado = $valorAnulado;
+  }
+
+  /**
+   * Retorna o valor anulado do item
+   * @return float $nValorAnulado
+   */
+  public function getValorAnulado() {
+    return $this->nValorAnulado;
+  }
+
   public function __construct( $iCodigoLancamento = null) {
 
     if (!empty($iCodigoLancamento)) {
@@ -144,6 +166,7 @@ class ItemOrdemDeCompra {
 
       $sCamposMatOrdemItem  = "m52_codlanc, m52_quant, m52_valor, m52_vlruni, e62_sequencial, ";
       $sCamposMatOrdemItem .= "(select coalesce(sum(m36_qtd), 0) from matordemitemanu where m36_matordemitem = m52_codlanc) as qtdanulado";
+      $sCamposMatOrdemItem .= ", (select coalesce(sum(m36_vrlanu), 0) from matordemitemanu where m36_matordemitem = m52_codlanc) as vlranulado";
 
       $sSqlMatOrdemItem = $oDaoMatOrdemItem->sql_queryItemEmpenho(null, $sCamposMatOrdemItem, null, "m52_codlanc = ". $iCodigoLancamento);
       $rsMatOrdemItem   = $oDaoMatOrdemItem->sql_record($sSqlMatOrdemItem);
@@ -159,6 +182,7 @@ class ItemOrdemDeCompra {
         $this->setValor($oDadosMatOrdemItem->m52_valor);
         $this->setValorUnitario($oDadosMatOrdemItem->m52_vlruni);
         $this->setQuantidadeAnulada($oDadosMatOrdemItem->qtdanulado);
+        $this->setValorAnulado($oDadosMatOrdemItem->vlranulado);
       }
     }
   }

--- a/model/compras/OrdemDeCompra.model.php
+++ b/model/compras/OrdemDeCompra.model.php
@@ -52,6 +52,12 @@ class OrdemDeCompra {
   private $oAnulacao;
 
   /**
+   * Observação da anulação da ordem
+   * @var ?string
+   */
+  private $sObsAnulacao;
+
+  /**
    * departamento da ordem de compra
    * @var DBDepartamento
    */
@@ -80,6 +86,12 @@ class OrdemDeCompra {
    * @var float
    */
   private $nTotalOrdem;
+
+  /**
+   * valor anulado da ordem
+   * @var ?float
+   */
+  private $nValorAnulado;
 
   /**
    * valor lancado
@@ -145,6 +157,8 @@ class OrdemDeCompra {
       $sCamposMatOrdem .= "m51_valortotal , ";
       $sCamposMatOrdem .= "m53_data       , ";
       $sCamposMatOrdem .= "($sSqlMatestoqueitemoc) as valorlancado ";
+      $sCamposMatOrdem .= ", m53_obs      , ";
+      $sCamposMatOrdem .= "(select coalesce(sum(m36_vrlanu), 0) from matordemitemanu inner join matordemitem on matordemitemanu.m36_matordemitem = matordemitem.m52_codlanc and m52_codordem = {$this->iCodigoOrdem}) as valoranulado ";
 
       $sSqlMatOrdem = $oDaoMatOrdem->sql_query_tot( null,$sCamposMatOrdem , null, "m51_codordem = {$iCodigoOrdem}");
       $rsMatOrdem   = $oDaoMatOrdem->sql_record($sSqlMatOrdem);
@@ -154,7 +168,7 @@ class OrdemDeCompra {
       }
 
       $oDadosMatOrdem = db_utils::fieldsMemory($rsMatOrdem, 0);
-      $nLancar        = $oDadosMatOrdem->m51_valortotal - $oDadosMatOrdem->valorlancado;
+      $nLancar        = $oDadosMatOrdem->m51_valortotal - $oDadosMatOrdem->valoranulado - $oDadosMatOrdem->valorlancado;
       $this->iCodigoFornecedor = $oDadosMatOrdem->m51_numcgm;
       $this->iCodigoDepartamento = $oDadosMatOrdem->m51_depto;
       $this->setEmissao(new DBDate($oDadosMatOrdem->m51_data));
@@ -162,6 +176,7 @@ class OrdemDeCompra {
       $this->setTipoCompra($oDadosMatOrdem->m51_tipo);
       $this->setTotalOrdem($oDadosMatOrdem->m51_valortotal);
       $this->setValorLancado($oDadosMatOrdem->valorlancado);
+      $this->setValorAnulado($oDadosMatOrdem->valoranulado);
       $this->setValorLancar($nLancar);
 
 
@@ -171,6 +186,7 @@ class OrdemDeCompra {
        */
       if ( $oDadosMatOrdem->m53_data != '' ) {
         $this->setAnulacao(new DBDate($oDadosMatOrdem->m53_data));
+        $this->setObsAnulacao(substr($oDadosMatOrdem->m53_obs, 0, 90));
       }
     }
   }
@@ -221,6 +237,22 @@ class OrdemDeCompra {
    */
   public function setAnulacao(DBDate $oDataAnulacao){
     $this->oAnulacao  = $oDataAnulacao;
+  }
+
+  /**
+   * retorna a observação de anulacao da ordem de compra
+   * @return string
+   */
+  public function getObsAnulacao(){
+    return $this->sObsAnulacao;
+  }
+
+  /**
+   * definimos a observação de anulação da ordem de compra
+   * @param ?string $sObsAnulacao
+   */
+  public function setObsAnulacao(?string $sObsAnulacao){
+    $this->sObsAnulacao = $sObsAnulacao;
   }
 
   /**
@@ -331,6 +363,22 @@ class OrdemDeCompra {
     $this->nTotalOrdem = $nTotalOrdem;
   }
 
+    /**
+   * retorna valor anulado da ordem
+   * @return float
+   */
+  public function getValorAnulado() {
+    return $this->nValorAnulado;
+  }
+
+  /**
+   * define valor anulado da ordem
+   * @param float
+   */
+  public function setValorAnulado($nValorAnulado) {
+    $this->nValorAnulado = $nValorAnulado;
+  }
+
   /**
    * retorna valor a lancar
    * @return float
@@ -393,7 +441,7 @@ class OrdemDeCompra {
     if (count($this->aItens) == 0) {
 
       $oDaoMatOrdemItem  = db_utils::getDao('matordemitem');
-      $sSqlItens         = $oDaoMatOrdemItem->sql_query_ordcons(null, 'm52_codlanc', null, "m52_codordem = ".$this->getCodigoOrdem());
+      $sSqlItens         = $oDaoMatOrdemItem->sql_query_ordcons(null, 'm52_codlanc', "m52_sequen", "m52_codordem = ".$this->getCodigoOrdem());
       $rsMatOrdemItem    = $oDaoMatOrdemItem->sql_record($sSqlItens);
 
       if ($oDaoMatOrdemItem->erro_status == "0") {

--- a/resources/legacy/compras/com3_itemordemdecompra002.php
+++ b/resources/legacy/compras/com3_itemordemdecompra002.php
@@ -75,40 +75,34 @@ js_gridItens();
   oGridItens.nameInstance = 'oGridItens';
   oGridItens.setCellWidth(['80px' ,
                            '80px' ,
-                           '80px' ,
                            '270px',
-                           '70px' ,
-                           '260px',
 //                           '270px',
                            '70px',
                            '80px',
                            '80px',
-                           '80px']);
+                           '80px',
+                           '80px',]);
 
   oGridItens.setCellAlign(['center'  ,
-                           'center'  ,
-                           'center'  ,
-                           'left',
                            'center'  ,
                            'left',
 //                           'left',
                            'right'  ,
                            'right'  ,
                            'right'  ,
+                           'right'  ,
                            'right']);
 
 
-  oGridItens.setHeader(['Núm. Empenho',
-                        'Cód. Empenho',
-                        'Cód. Material',
-                        'Descrição Material',
-                        'Sequencial',
-                        'Descrição Solicitação',
+  oGridItens.setHeader(['Empenho',
+                        'Ordem',
+                        'Item',
 //                        'Observação',
                         'Quantidade',
                         'Valor Unitário',
                         'Valor Total',
-                        'Qtd Anulada']);
+                        'Qtd Anulada',
+                        'Vlr. Anulado']);
 
 //  oGridItens.aHeaders[6].lDisplayed = false;
 
@@ -155,15 +149,13 @@ js_gridItens();
 
        var aRow     = [];
            aRow[0]  = oDado.sNumeroEmpenho                   ;
-           aRow[1]  = oDado.iCodigoEmpenho                   ;
-           aRow[2]  = oDado.iCodigoMaterial                  ;
-           aRow[3]  = oDado.sDescricaoMaterial.urlDecode()   ;
-           aRow[4]  = oDado.iSequencia                       ;
-           aRow[5]  = oDado.sDescricaoSolicitacao.urlDecode().substr(0, 45) ;
-           aRow[6]  = '&nbsp;' + oDado.iQuantidade           ;
-           aRow[7]  = oDado.nValorUnitario                   ;
-           aRow[8]  = oDado.nValorTotal                      ;
-           aRow[9] = oDado.nQuantidadeAnulada               ;
+           aRow[1]  = oDado.iSequencia                       ;
+           aRow[2]  = oDado.sDescricaoMaterial.urlDecode().substr(0, 45)   ;
+           aRow[3]  = '&nbsp;' + oDado.iQuantidade           ;
+           aRow[4]  = oDado.nValorUnitario                   ;
+           aRow[5]  = oDado.nValorTotal                      ;
+           aRow[6] = oDado.nQuantidadeAnulada               ;
+           aRow[7] = oDado.nValorAnulado                     ;
            oGridItens.addRow(aRow);
 
    });
@@ -174,7 +166,7 @@ js_gridItens();
       oParametros = {iWidth:'150', oPosition : {sVertical : 'T', sHorizontal : 'L'}};
      // oGridItens.setHint(iLinha, 1, oDado.sDebito,  oParametros);
       // ou sem passar parametros
-      oGridItens.setHint(iLinha, 5, oDado.sDescricaoSolicitacao.urlDecode());
+      oGridItens.setHint(iLinha, 2, oDado.sDescricaoCompleta.urlDecode());
     });
 
  }

--- a/resources/legacy/compras/com3_ordemdecompra002.php
+++ b/resources/legacy/compras/com3_ordemdecompra002.php
@@ -85,18 +85,18 @@ if ($oOrdemCompra->getEmpenhoFinanceiro()->getInstituicao()->getCodigo() != db_g
     <table width="100%" border="0" >
 
       <tr>
-        <td class='negrito' width="150" >
+        <td class='negrito' width="108px" >
           Código:
         </td>
         <td class='dados' colspan="3">
           <label id='iCodigo'></label>
         </td>
-        <td rowspan="7" id="tdObservacoes" width="800" valign="top">
+        <td rowspan="4" id="tdObservacoes"  colspan="2" width="800" valign="top">
         </td>
       </tr>
 
       <tr>
-        <td class='negrito'>
+        <td class='negrito' width="108px">
           Fornecedor:
         </td>
         <td class='dados' colspan="3">
@@ -105,70 +105,74 @@ if ($oOrdemCompra->getEmpenhoFinanceiro()->getInstituicao()->getCodigo() != db_g
       </tr>
 
       <tr>
-        <td class='negrito' width="150">
+        <td class='negrito' width="108px">
           Data de Emissão:
         </td>
-        <td class='dados' nowrap="nowrap" >
+        <td class='dados' colspan="3">
           <label id='dtEmissao'></label>
         </td>
+      </tr>
 
-        <td class='negrito'width="150">
-          Data de Anulação:
+      <tr>
+        <td class='negrito' width="108px">
+          Departamento:
+        </td>
+        <td class='dados' colspan="3">
+          <label id='sDepartamento'></label>
+        </td>
+      </tr>
+
+      <tr>
+        <td class='negrito' width="108px">
+          Total da Ordem:
+        </td>
+        <td class='dados' >
+          <label id='nTotalOrdem'></label>
+        </td>
+
+        <td class='negrito' width="108px">
+          Valor Lançado:
+        </td>
+        <td class='dados' >
+          <label id='nValorLancado'></label>
+        </td>
+
+        <td class='negrito' width="108px">
+          Data Anulação:
         </td>
         <td class='dados' >
           <label id='dtAnulacao'></label>
         </td>
       </tr>
-
-       <tr>
-        <td class='negrito' width="150">
-          Departamento:
+      
+      <tr>
+        <td class='negrito' width="108px">
+          Valor Anulado:
         </td>
         <td class='dados' >
-          <label id='sDepartamento'></label>
+          <label id='nValorAnulado'></label>
         </td>
 
-        <td class='negrito'width="150">
-          Tipo de Compra:
-        </td>
-        <td class='dados' >
-          <label id='sTipoCompra'></label>
-        </td>
-      </tr>
-
-      <tr>
-        <td class='negrito'>
-          Total da Ordem:
-        </td>
-        <td class='dados' colspan="3">
-          <label id='nTotalOrdem'></label>
-        </td>
-      </tr>
-
-      <tr>
-        <td class='negrito'>
-          Valor Lançado:
-        </td>
-        <td class='dados' colspan="3">
-          <label id='nValorLancado'></label>
-        </td>
-      </tr>
-
-      <tr>
-        <td class='negrito'>
+        <td class='negrito' width="108px">
           A Lançar:
         </td>
-        <td class='dados' colspan="3">
+        <td class='dados' >
           <label id='nValorLancar'></label>
         </td>
-      </tr>
 
+        <td class='negrito' width="108px">
+          Obs. Anulação:
+        </td>
+        <td class='dados' >
+          <label id='sObsAnulacao'></label>
+        </td>
+      </tr>
 
       <tr id="trObservacaoInicial">
         <td class='negrito'>
           Observações:
         </td>
-        <td class='dados' colspan="3">
+        <td class='dados' >
           <textarea id="textAreaObs" rows="3" style="resize:none;overflow:auto; width: 100%; border: none;" readonly="readonly">
           </textarea>
         </td>
@@ -240,8 +244,10 @@ function js_retornoDadosOrdem(oAjax){
   $("sDepartamento").innerHTML = oRetorno.oDadosOrdem.iDepto + " - " + oRetorno.oDadosOrdem.sDepto.urlDecode();
   $("sFornecedor").innerHTML   = oRetorno.oDadosOrdem.iCgm   + " - " + oRetorno.oDadosOrdem.sCgm.urlDecode();
   $("dtAnulacao").innerHTML    = oRetorno.oDadosOrdem.dAnulacao;
-  $("sTipoCompra").innerHTML   = sTipoCompra.urlDecode();
+  $("sObsAnulacao").innerHTML  = oRetorno.oDadosOrdem.sObsAnulacao;
+  //$("sTipoCompra").innerHTML   = sTipoCompra.urlDecode(); // Retirado por nao ser relevante ao usuario
   $("nTotalOrdem").innerHTML   = oRetorno.oDadosOrdem.nTotalOrdem;
+  $("nValorAnulado").innerHTML = oRetorno.oDadosOrdem.nValorAnulado;
   $("nValorLancado").innerHTML = oRetorno.oDadosOrdem.nValorLancado;
   $("nValorLancar").innerHTML  = oRetorno.oDadosOrdem.nValorLancar;
   $("textAreaObs").value       = oRetorno.oDadosOrdem.sObservacao.urlDecode();
@@ -280,7 +286,7 @@ function js_verificarResolucaoUsuario() {
      * Setamos o estilo no textarea e adicionamos ele ao fieldset
      */
     $('textAreaObs').style.width  = '100%';
-    $('textAreaObs').rows   = '7';
+    $('textAreaObs').rows   = '4';
     oFieldset.appendChild($('textAreaObs'));
     $("tdObservacoes").appendChild(oFieldset);
     $("tdObservacoes").vAlign = 'top';

--- a/resources/legacy/compras/com4_ordemdecompra001.RPC.php
+++ b/resources/legacy/compras/com4_ordemdecompra001.RPC.php
@@ -62,13 +62,16 @@ try {
       $oDadosOrdem->sCgm          = urlencode($oOrdemCompra->getFornecedor()->getNome());
       $oDadosOrdem->sObservacao   = urlencode($oOrdemCompra->getObservacao());
       $oDadosOrdem->dAnulacao     = '';
+      $oDadosOrdem->sObsAnulacao  = '';
       $oDadosOrdem->iTipoCompra   = $oOrdemCompra->getTipoCompra();
       $oDadosOrdem->nTotalOrdem   = db_formatar($oOrdemCompra->getTotalOrdem(), 'f');
+      $oDadosOrdem->nValorAnulado = db_formatar($oOrdemCompra->getValorAnulado(), 'f');
       $oDadosOrdem->nValorLancado = db_formatar($oOrdemCompra->getValorLancado(), 'f');
       $oDadosOrdem->nValorLancar  = db_formatar($oOrdemCompra->getValorLancar(), 'f');
 
       if ($oOrdemCompra->getAnulacao()){
         $oDadosOrdem->dAnulacao    = db_formatar($oOrdemCompra->getAnulacao()->getDate(),'d');
+        $oDadosOrdem->sObsAnulacao = db_formatar($oOrdemCompra->getObsAnulacao(),'s');
       }
       $oRetorno->oDadosOrdem = $oDadosOrdem;
 
@@ -92,15 +95,14 @@ try {
 
         $oDadosItem = new stdClass();
         $oDadosItem->sNumeroEmpenho        = $oEmpenhoFinanceiro->getCodigo() . "/" . $oEmpenhoFinanceiro->getAnoUso();
-        $oDadosItem->iCodigoEmpenho        = $oEmpenhoFinanceiro->getNumero();
-        $oDadosItem->iCodigoMaterial       = $oEmpenhoItem->getItemMaterialCompras()->getMaterial();
-        $oDadosItem->sDescricaoMaterial    = $oEmpenhoItem->getItemMaterialCompras()->getDescricao();
         $oDadosItem->iSequencia            = $oEmpenhoItem->getSequencialAutorizacaoItem();
-        $oDadosItem->sDescricaoSolicitacao = urlencode($oEmpenhoItem->getDescricao());
+        $oDadosItem->sDescricaoMaterial    = "{$oEmpenhoItem->getItemMaterialCompras()->getMaterial()} - {$oEmpenhoItem->getItemMaterialCompras()->getDescricao()}";
+        $oDadosItem->sDescricaoCompleta    = "{$oEmpenhoItem->getItemMaterialCompras()->getDescricao()}. {$oEmpenhoItem->getItemMaterialCompras()->getComplemento()}";
         $oDadosItem->iQuantidade           = $oItemOrdemDeCompra->getQuantidade();
         $oDadosItem->nValorUnitario        = db_formatar($oItemOrdemDeCompra->getValorUnitario(), 'f');
         $oDadosItem->nValorTotal           = db_formatar($oItemOrdemDeCompra->getValor(), 'f');
         $oDadosItem->nQuantidadeAnulada    = $iQuantidadeAnulada;
+        $oDadosItem->nValorAnulado         = db_formatar($oItemOrdemDeCompra->getValorAnulado(), 'f');
         $oRetorno->aItensOrdem[] = $oDadosItem;
       }
 


### PR DESCRIPTION
## Objetivo

Aprimorar a rotina **Compras > Consultas > Ordem de Compra (Novo)** para concentrar nela as informações necessárias à consulta da Ordem de Compra, permitindo a desativação da rotina anterior.

O foco desta alteração foi complementar as informações apresentadas, reorganizar a visualização dos itens e aproximar a nova consulta das informações existentes na rotina antiga.

## Alterações realizadas

### Dados da Ordem de Compra

- Adicionada a **observação da anulação**, utilizando o campo `m53_obs`.
- Adicionado o **Valor Anulado** da Ordem de Compra.
- Ajustado o cálculo do valor **A Lançar**, passando a considerar:

  `Valor Total - Valor Anulado - Valor Lançado`

- Reorganizado o layout dos dados apresentados na consulta.

### Lista de itens

A grid de itens foi reorganizada para apresentar as informações de forma mais direta.

Foram removidas as colunas:

- Código interno do empenho;
- Código isolado do material;
- Descrição da solicitação.

A nova organização apresenta:

- Empenho;
- Sequência do item na ordem;
- Material e descrição;
- Quantidade;
- Valor unitário;
- Valor total;
- Quantidade anulada;
- Valor anulado.

O número do empenho continua sendo apresentado na forma `número/ano`.

Também foi incluído o **valor anulado individualmente por item**.

### Descrição do material

A descrição do material passou a considerar também o campo de complemento (`pc01_complmater`).

Na grid, o material é apresentado de forma resumida e a descrição completa, incluindo o complemento, permanece disponível através do detalhamento/hint do item.

### Visualização

O layout da consulta foi reorganizado para melhor aproveitamento do espaço disponível, incluindo os novos dados de anulação.

Também foram ajustadas as colunas da grid para que todas as informações relevantes estejam visíveis ao acessar a consulta.

### Menu anterior

A rotina anterior de consulta de Ordem de Compra foi desativada, concentrando a utilização na rotina **Ordem de Compra (Novo)**.

## Itens não implementados nesta entrega

Alguns pontos levantados inicialmente foram avaliados, mas não foram incluídos nesta entrega.

### Unidade de medida

A inclusão da unidade de medida na grid foi postergada.

Apesar de ser uma informação útil, sua obtenção e apresentação demandariam alterações adicionais no fluxo atual e aumentariam a complexidade de uma entrega cujo objetivo é realizar a unificação da consulta de maneira mais rápida.

### Histórico de alterações

Não foi implementado nesta entrega.

Não foi identificado no fluxo atual um histórico estruturado da Ordem de Compra que pudesse ser reutilizado diretamente.

O item permanece como **TODO** para análise e implementação futura.

## Resultado esperado

Com isso, a rotina anterior será desabilitada para o usuário e a consulta passa a ser concentrada em **Compras > Consulta > Ordem de Compra (Novo)**.

## Testes

Não foram implementados testes automatizados pois foram realizadas alterações pontuais em arquivos já existentes, mas segue prints que demonstram a funcionalidade:

<img width="1366" height="768" alt="Captura de tela 2026-08-29 - 21 56 56" src="https://github.com/user-attachments/assets/39db04ff-6bb6-4662-9a2a-311a93358363" />

<img width="1366" height="768" alt="Captura de tela 2026-08-29 - 21 56 56" src="https://github.com/user-attachments/assets/7ff3eefd-022a-454c-a846-7e5861ce7448" />

<img width="1366" height="768" alt="Captura de tela 2026-08-29 - 21 56 56" src="https://github.com/user-attachments/assets/9824204f-0bde-469e-9437-735b7c4d262b" />

